### PR TITLE
Fix developer QA flow regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 .vscode
 ptau_files/
 CONTINUITY.md
+.worktrees/

--- a/src/helpers/contracts.ts
+++ b/src/helpers/contracts.ts
@@ -20,6 +20,8 @@ const RPC_URL: Record<ChainId, string> = {
   8453: "https://mainnet.base.org",
 };
 
+export const ZERO_BYTES32 = "0x" + "0".repeat(64);
+
 export function getDefaultVerifier(chainId: ChainId): string {
   return chainId === 8453
     ? baseNet.addresses.contracts.UnifiedPaymentVerifierV2
@@ -42,7 +44,10 @@ export async function fetchIntentDetails(
   chainId: ChainId,
   intentHashHex: string
 ): Promise<IntentDetails> {
-  const provider = new ethers.providers.JsonRpcProvider(RPC_URL[chainId], chainId);
+  const provider = new ethers.providers.JsonRpcProvider(
+    RPC_URL[chainId],
+    chainId
+  );
   const orchestrator = new ethers.Contract(
     getOrchestratorAddress(chainId),
     getOrchestratorAbi(chainId),
@@ -69,7 +74,7 @@ export function normalizeHex32(value: string): string {
   const v = (value || "").trim();
   const prefixed = v.startsWith("0x") ? v : `0x${v}`;
   if (prefixed === "0x" || prefixed === "0x0") {
-    return "0x" + "0".repeat(64);
+    return ZERO_BYTES32;
   }
   const hex = prefixed.length % 2 === 0 ? prefixed : "0x0" + prefixed.slice(2);
   if (!ethers.utils.isHexString(hex)) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,10 +30,12 @@ import {
   fetchIntentDetails,
   normalizeHex32,
   hexToDecimal,
+  ZERO_BYTES32,
 } from "@helpers/contracts";
 
 const CHROME_EXTENSION_URL =
   "https://chromewebstore.google.com/detail/zkp2p-extension/ijpgccednehjpeclfcllnjjcmiohdjih";
+const INSTALL_BUTTON_RESET_MS = 1500;
 const PROOF_FETCH_INTERVAL = 3000;
 const PROOF_GENERATION_TIMEOUT = 60000;
 
@@ -41,8 +43,7 @@ const PROOF_GENERATION_TIMEOUT = 60000;
 const DEFAULT_CALLDATA_INPUTS = {
   intentAmount: "0",
   intentTimestamp: "0",
-  payeeDetails:
-    "0x0000000000000000000000000000000000000000000000000000000000000000",
+  payeeDetails: ZERO_BYTES32,
   fiatCurrency: keccak256("USD"),
   conversionRate: "0",
 };
@@ -121,6 +122,22 @@ const normalizeProofPayload = (
   throw new Error(
     "Invalid proof JSON. Expected a proof object or an array of proof objects."
   );
+};
+
+const getIntentFetchErrorMessage = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    return "Failed to fetch intent from chain";
+  }
+
+  if (
+    error.message === "Intent not found" ||
+    error.message.includes("CALL_EXCEPTION") ||
+    error.message.includes("missing revert data")
+  ) {
+    return "Intent not found for that hash on the selected chain.";
+  }
+
+  return error.message;
 };
 
 // Step indicator component
@@ -218,6 +235,7 @@ const Home: React.FC = () => {
   const [triggerProofFetchPolling, setTriggerProofFetchPolling] =
     useState(false);
   const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null);
+  const installResetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const proofTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const [calldataInputs, setCalldataInputs] = useState(DEFAULT_CALLDATA_INPUTS);
@@ -353,9 +371,24 @@ const Home: React.FC = () => {
     }
   }, [proofStatus, intervalId]);
 
+  useEffect(() => {
+    return () => {
+      if (installResetTimeoutRef.current) {
+        clearTimeout(installResetTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleInstall = () => {
     window.open(CHROME_EXTENSION_URL, "_blank");
     setIsInstallClicked(true);
+    if (installResetTimeoutRef.current) {
+      clearTimeout(installResetTimeoutRef.current);
+    }
+    installResetTimeoutRef.current = setTimeout(() => {
+      setIsInstallClicked(false);
+      installResetTimeoutRef.current = null;
+    }, INSTALL_BUTTON_RESET_MS);
   };
 
   const handlePaymentPlatformChange = (
@@ -374,6 +407,7 @@ const Home: React.FC = () => {
   };
 
   const handleOpenSettings = () => {
+    if (!isSidebarInstalled) return;
     openSidebar("/settings");
   };
 
@@ -604,16 +638,21 @@ const Home: React.FC = () => {
   // Handle pasted proof changes
   const handlePastedProofChange = (value: string) => {
     setResultProof(value);
-    // Try to validate if it's a valid proof JSON
-    if (value.trim()) {
-      try {
-        const parsed = JSON.parse(value);
-        normalizeProofPayload(parsed);
-        setProofStatus("success");
-      } catch {
-        // Not valid JSON yet, keep current status
-      }
-    } else {
+    setAttestationResponse(null);
+    setAttestationError(null);
+    setGeneratedCalldata("");
+    setCalldataError(null);
+
+    if (!value.trim()) {
+      setProofStatus("idle");
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(value);
+      normalizeProofPayload(parsed);
+      setProofStatus("success");
+    } catch {
       setProofStatus("idle");
     }
   };
@@ -627,6 +666,8 @@ const Home: React.FC = () => {
       setProofStatus("idle");
       setAttestationResponse(null);
       setAttestationError(null);
+      setGeneratedCalldata("");
+      setCalldataError(null);
     }
   };
 
@@ -642,6 +683,11 @@ const Home: React.FC = () => {
       setFetchIntentLoading(true);
       const netChain: 84532 | 8453 = chainId === 8453 ? 8453 : 84532;
       const hex = normalizeHex32(verifyIntentHash);
+      if (hex === ZERO_BYTES32) {
+        throw new Error(
+          "Enter a non-zero intent hash before fetching intent details."
+        );
+      }
       const onchain = await fetchIntentDetails(netChain, hex);
       setCalldataInputs({
         intentAmount: onchain.amount,
@@ -651,8 +697,8 @@ const Home: React.FC = () => {
         payeeDetails: onchain.payeeDetails || calldataInputs.payeeDetails,
       });
       setPaymentMethodHex(onchain.paymentMethod);
-    } catch (e: any) {
-      setFetchIntentError(e?.message || "Failed to fetch intent from chain");
+    } catch (error) {
+      setFetchIntentError(getIntentFetchErrorMessage(error));
     } finally {
       setFetchIntentLoading(false);
     }
@@ -675,8 +721,12 @@ const Home: React.FC = () => {
                 </StatusValue>
                 <IconButton
                   onClick={handleOpenSettings}
-                  disabled={proofStatus === "generating"}
-                  title="Open Settings"
+                  disabled={proofStatus === "generating" || !isSidebarInstalled}
+                  title={
+                    isSidebarInstalled
+                      ? "Open Settings"
+                      : "Install the extension to open settings"
+                  }
                 >
                   Open Settings
                   <StyledChevronRight />
@@ -762,6 +812,7 @@ const Home: React.FC = () => {
                     leftAccessorySvg={browserSvgIcon()}
                     loading={isInstallClicked}
                     disabled={isInstallClicked}
+                    loadingText="Opening store..."
                     height={48}
                     width={216}
                   >


### PR DESCRIPTION
## Summary
This patch fixes the browser QA regressions found on `developer.peer.xyz` while walking the primary developer flows without the extension installed. On the live site, Step 1 left an actionable `Open Settings` button enabled even when no extension was present, Step 3 could remain in a stale "valid proof" state after the pasted JSON became invalid, and Step 4 surfaced raw chain/ethers errors when the placeholder `0x` intent hash was fetched. Those states made the UI look actionable when it was not and could leave downstream verification controls enabled against invalid inputs.

The root cause was a combination of missing state guards and incomplete reset logic. `Open Settings` only respected proof-generation loading, not extension availability. The install CTA set a permanent clicked/loading flag after opening the Chrome Web Store. Pasted proof validation only moved state forward to success and never cleared verification state or downstream outputs when the proof became invalid. Intent fetches normalized `0x` into a zero bytes32 hash and then forwarded raw provider errors back into the UI.

## Fixes
The changes harden each of those transitions directly in the developer UI. `Open Settings` is now disabled until the extension is actually installed and exposes a helpful tooltip explaining why. The install CTA still shows a loading state when the store opens, but it now resets so the user can retry instead of being stuck on a disabled button. Pasted proof edits now clear attestation/calldata output, re-validate the payload on every change, and drop back to idle when the JSON is invalid or unsupported so `Verify Proof` cannot stay enabled on stale input. Intent fetching now blocks the zero-hash placeholder up front and maps low-level contract/provider failures to a user-readable "intent not found" error.

The patch also adds `.worktrees/` to `.gitignore` so local worktree directories stay out of staging on non-main branches, matching the repo workflow guidance.

## Validation
I validated the fixes in two ways:

1. Live QA on `https://developer.peer.xyz` to reproduce the original regressions:
   - `Open Settings` remained clickable while version showed `Not Installed`
   - `Paste Proof` stayed in a valid state after changing valid JSON to invalid text
   - `Fetch Intent` with the default `0x` value surfaced a raw `CALL_EXCEPTION`
2. Local verification on this branch after patching:
   - `yarn start` and Chrome DevTools against `http://localhost:3000`
   - confirmed `Open Settings` is disabled with explanatory text when the extension is absent
   - confirmed `Add to Chrome` recovers from its loading state and becomes clickable again
   - confirmed pasted invalid JSON clears the valid state and disables `Verify Proof`
   - confirmed `Fetch Intent` now shows `Enter a non-zero intent hash before fetching intent details.` for the placeholder hash
   - `yarn build`
