### PR TITLE
Fix metadata platform lookup key mismatch

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,10 +48,8 @@ const DEFAULT_CALLDATA_INPUTS = {
 };
 
 // Helper: derive platform (e.g., "venmo") from action type (e.g., "transfer_venmo").
-const derivePlatformFromActionType = (action: string, fallback: string) => {
-  if (!action) return fallback;
-  const parts = action.split("_");
-  return parts.length > 1 ? parts[parts.length - 1] : fallback;
+const derivePlatformFromActionType = (_action: string, fallback: string) => {
+  return fallback;
 };
 
 type GenericRecord = Record<string, unknown>;


### PR DESCRIPTION
## Summary
- `derivePlatformFromActionType` splits action type by `_` and takes the last segment (e.g., `transfer_upi` → `upi`), but the extension stores metadata keyed by `metadata.platform` from the provider JSON (e.g., `amazonpay`)
- This causes the AVAILABLE METADATA section to show "Authenticate to see available metadata" even when metadata was successfully received (confirmed via console logs)
- Affects Amazon Pay UPI (`transfer_upi` vs `amazonpay`) and all Zelle providers (`transfer_zelle` vs `chase`/`citi`/`bankofamerica`)
- Fix: use `paymentPlatform` input directly since it always matches the extension's `metadata.platform` key

## Test plan
- [ ] Set Action Type to `transfer_upi`, Payment Platform to `amazonpay`, click AUTHENTICATE
- [ ] Verify metadata rows render in the AVAILABLE METADATA section
- [ ] Verify Zelle providers (e.g., chase/transfer_zelle) still show metadata correctly
- [ ] Verify Venmo (transfer_venmo/venmo) still works (no regression since derived name matches)